### PR TITLE
Added missing translate button to taxons index

### DIFF
--- a/app/overrides/spree/admin/taxonomies/_list/add_translations.rb
+++ b/app/overrides/spree/admin/taxonomies/_list/add_translations.rb
@@ -6,3 +6,12 @@ Deface::Override.new(
                     <%= link_to_with_icon 'translate', nil, spree.admin_translations_path('taxonomies', taxonomy.id), title: Spree.t(:'i18n.translations'), class: 'btn btn-sm btn-primary', no_text: true %>
                   HTML
 )
+
+Deface::Override.new(
+  virtual_path:  'spree/admin/shared/sortable_tree/_taxonomy',
+  name:          'taxons_translation',
+  insert_bottom: 'div.space-buttons',
+  text:           <<-HTML
+                    <%= link_to_with_icon 'translate', nil, spree.admin_translations_path('taxons', taxon.id), title: Spree.t(:'i18n.translations'), class: 'btn btn-sm btn-primary', no_text: true %>
+                  HTML
+)


### PR DESCRIPTION
Hey @mrbrdo 

The translation button was missing for taxons, I've added it. 
Not sure I placed the override at the right place though. I found it logical to place it in the same file as the one for taxonomies, but... 

Let me know!