### PR TITLE
Add relation types translations

### DIFF
--- a/app/overrides/spree/admin/relation_types/index/add_translation.rb
+++ b/app/overrides/spree/admin/relation_types/index/add_translation.rb
@@ -1,0 +1,8 @@
+Deface::Override.new(
+  virtual_path:  'spree/admin/relation_types/index',
+  name:          'relation_types_index_translation',
+  insert_top:    'td.actions',
+  text:          <<-HTML
+                  <%= link_to_with_icon 'translate', nil, spree.admin_translations_path('relation_types', relation_type.id), title: Spree.t(:'i18n.translations'), class: 'btn btn-sm btn-primary', no_text: true %>
+                HTML
+)

--- a/app/overrides/spree/admin/taxonomies/_list/add_translations.rb
+++ b/app/overrides/spree/admin/taxonomies/_list/add_translations.rb
@@ -6,3 +6,12 @@ Deface::Override.new(
                     <%= link_to_with_icon 'translate', nil, spree.admin_translations_path('taxonomies', taxonomy.id), title: Spree.t(:'i18n.translations'), class: 'btn btn-sm btn-primary', no_text: true %>
                   HTML
 )
+
+Deface::Override.new(
+  virtual_path:  'spree/admin/shared/sortable_tree/_taxonomy',
+  name:          'taxons_translation',
+  insert_bottom: 'div.space-buttons',
+  text:           <<-HTML
+                    <%= link_to_with_icon 'translate', nil, spree.admin_translations_path('taxons', taxon.id), title: Spree.t(:'i18n.translations'), class: 'btn btn-sm btn-primary', no_text: true %>
+                  HTML
+)

--- a/app/views/spree/admin/translations/relation_type.html.erb
+++ b/app/views/spree/admin/translations/relation_type.html.erb
@@ -1,0 +1,9 @@
+<% content_for :page_title do %>
+  <%= Spree.t(:editing_resource, resource: Spree::RelationType.model_name.human) %> <span class="green">"<%= @relation_type.name %>"</span>
+<% end %>
+
+<% content_for :page_actions do %>
+  <%= button_link_to Spree.t(:back_to_resource_list, resource: Spree::RelationType.model_name.human), spree.admin_relation_types_path, class: 'btn-primary', icon: 'arrow-left' %>
+<% end %>
+
+<%= render 'form' %>

--- a/db/migrate/20220627143005_add_translations_to_related_products.rb
+++ b/db/migrate/20220627143005_add_translations_to_related_products.rb
@@ -1,0 +1,54 @@
+class AddTranslationsToRelatedProducts < ActiveRecord::Migration[4.2]
+  def up
+    unless table_exists?(:spree_relation_type_translations)
+      params = { name: :string, description: :text }
+      create_translation_table(:spree_relation_type, params)
+      migrate_data(Spree::RelationType, params) if defined?(Spree::RelationType)
+    end
+  end
+
+  def down
+    drop_table :spree_relation_type_translations
+  end
+
+  protected
+
+  def create_translation_table(table, params)
+    create_table :"#{table}_translations" do |t|
+
+      # Translated attribute(s)
+      params.each_pair do |attr, attr_type|
+        t.send attr_type, attr
+      end
+
+      t.string  :locale, null: false
+      t.references table, null: false, foreign_key: true, index: false
+
+      t.timestamps null: false
+    end
+
+    add_index :"#{table}_translations", :locale, name: :"index_#{table}_translations_on_locale"
+    add_index :"#{table}_translations", [:"#{table}_id", :locale], name: :"index_#{table}_translations_on_id_and_locale", unique: true
+  end
+
+  def migrate_data(model_klass, fields)
+    store = Spree::Store.unscoped.first
+    return unless store
+    default_locale = store.default_locale.to_s
+    field_names = fields.keys + ['created_at', 'updated_at']
+    translation_table = "#{model_klass.table_name.singularize}_translations"
+    foreign_key = "#{model_klass.table_name.singularize}_id"
+
+    # In case we are migrating from Globalize with existing translations, skip this step
+    return if ActiveRecord::Base.connection.execute("SELECT id FROM #{translation_table}").any?
+    ActiveRecord::Base.connection.execute("SELECT id, #{field_names.join(',')} FROM #{model_klass.table_name}").each do |r|
+      field_values =
+        field_names.each_with_object([]) do |field_name, a|
+          a << r[field_name.to_s]
+        end
+
+      ActiveRecord::Base.connection.execute(ActiveRecord::Base.sanitize_sql_array(["INSERT INTO #{translation_table} (locale, #{foreign_key}, #{field_names.join(',')}) VALUES (?,?,#{(['?'] * field_names.size).join(',')})",
+        default_locale.to_s, r['id'], *field_values]))
+    end
+  end
+end

--- a/lib/spree_mobility.rb
+++ b/lib/spree_mobility.rb
@@ -68,6 +68,7 @@ module SpreeMobility
   def self.extend_reloadable_classes
     SpreeMobility.prepend_once(::Spree::OptionType, SpreeMobility::CoreExt::Spree::OptionTypeDecorator)
     SpreeMobility.prepend_once(::Spree::OptionValue, SpreeMobility::CoreExt::Spree::OptionValueDecorator)
+    SpreeMobility.prepend_once(::Spree::RelationType, SpreeMobility::CoreExt::Spree::RelationTypeDecorator)
     SpreeMobility.prepend_once(::Spree::Product, SpreeMobility::CoreExt::Spree::ProductDecorator)
     SpreeMobility.prepend_once(::Spree::Product.singleton_class, SpreeMobility::CoreExt::Spree::ProductDecorator::ClassMethods)
     SpreeMobility.prepend_once(::Spree::Product.singleton_class, SpreeMobility::CoreExt::Spree::ProductScopesWithMobilityDecorator)

--- a/lib/spree_mobility/core_ext/spree/relation_type_decorator.rb
+++ b/lib/spree_mobility/core_ext/spree/relation_type_decorator.rb
@@ -1,0 +1,15 @@
+module SpreeMobility::CoreExt::Spree::RelationTypeDecorator
+  def self.prepended(base)
+    base.include SpreeMobility::Translatable
+    SpreeMobility.translates_for base, :name, :description
+
+    base.translation_class.class_eval do
+      validates :name, presence: true, uniqueness: { scope: :locale, case_sensitive: false, allow_blank: true }
+    end
+  end
+
+  # Needed for admin
+  def json_api_columns
+    super + ['name', 'description']
+  end
+end

--- a/spec/models/translated_models_spec.rb
+++ b/spec/models/translated_models_spec.rb
@@ -7,6 +7,10 @@ module Spree
     include_context "behaves as translatable"
   end
 
+  RSpec.describe RelationType, type: :model do
+    include_context "behaves as translatable"
+  end
+
   RSpec.describe Taxon, type: :model do
     include_context "behaves as translatable"
   end


### PR DESCRIPTION
Hi @mrbrdo 

I've added translations for relation types from related products extension.
I don't know how to handle correctly the fact that the extension may not be used in Spree.
Any idea?

Otherwise, I just added code based on what you did for option types and payment method. 

Thanks!